### PR TITLE
Numpy synaptic matrix

### DIFF
--- a/pynn_spinnaker/spinnaker/regions/synaptic_matrix.py
+++ b/pynn_spinnaker/spinnaker/regions/synaptic_matrix.py
@@ -155,15 +155,11 @@ class SynapticMatrix(Region):
                     num_extension_words = 0
                     any_connections = False
                     for i, row in enumerate(rows):
-                        # Use bisect to find start and stop index of sub-row
-                        # **NOTE** rows are already sorted by index
-                        # http://stackoverflow.com/questions/15139299/performance-of-numpy-searchsorted-is-poor-on-structured-arrays
-                        sub_row_start = np.searchsorted(row["index"], vertex_slice.start, side="left")
-                        sub_row_end = np.searchsorted(row["index"], vertex_slice.stop, side="left")
-                        #sub_row_start = bisect_left(row["index"],
-                        #                            vertex_slice.start)
-                        #sub_row_end = bisect_left(row["index"],
-                        #                          vertex_slice.stop)
+                        # Find start and end of sub-row
+                        sub_row_start = np.searchsorted(
+                            row["index"], vertex_slice.start, side="left")
+                        sub_row_end = np.searchsorted(
+                            row["index"], vertex_slice.stop, side="left")
 
                         # Create copy of this slice of row
                         sub_row = np.copy(row[sub_row_start:sub_row_end])

--- a/pynn_spinnaker/spinnaker/regions/synaptic_matrix.py
+++ b/pynn_spinnaker/spinnaker/regions/synaptic_matrix.py
@@ -10,7 +10,6 @@ from rig.type_casts import NumpyFloatToFixConverter
 
 # Import functions
 from bisect import bisect_left
-from operator import itemgetter
 from six import iteritems
 from ..utils import get_row_offset_length
 
@@ -133,73 +132,84 @@ class SynapticMatrix(Region):
     # Public methods
     # --------------------------------------------------------------------------
     def partition_matrices(self, matrices, vertex_slice, incoming_connections):
-        # Create lambda function to group delays into groups
-        # that can be handled by the DTCM delay buffer
-        # **NOTE** subtract one so there is a minimum of 1 slot of delay
-        delay_grouper = lambda d: (d[1] - 1) // self.max_dtcm_delay_slots
-
         # Loop through all incoming connections
         sub_matrices = []
         for pre_pop, pre_neuron_vertices in iteritems(incoming_connections):
-            # Extract corresponding connection matrix
-            matrix = matrices[pre_pop]
+            # Extract corresponding matrix rows
+            pop_rows = matrices[pre_pop]
 
             # Loop through all the vertices that
             # make up the pre-synaptic population
             for pre_neuron_vertex in pre_neuron_vertices:
-                # Slice the rows out of the matrix (fast)
-                rows = matrix[pre_neuron_vertex.neuron_slice.python_slice]
+                # Slice out the row offsets for this vertex
+                rows = pop_rows[pre_neuron_vertex.neuron_slice.python_slice]
 
                 # If there are any rows
                 if len(rows) > 0:
                     # Create a numpy array to hold the rows of the sub-matrix
                     # Connecting this pre-neuron vertex to this vertexs-lice
-                    sub_rows = np.empty(len(rows), dtype=object)
+                    # Create list of lists to contain matrix rows
+                    sub_rows = [[] for _ in range(len(rows))]
+
                     max_cols = 1
                     num_extension_words = 0
                     any_connections = False
                     for i, row in enumerate(rows):
-                        # Extract indices
-                        row_idxs = [s.index for s in row]
-
                         # Use bisect to find start and stop index of sub-row
                         # **NOTE** rows are already sorted by index
-                        row_start = bisect_left(row_idxs, vertex_slice.start)
-                        row_end = bisect_left(row_idxs, vertex_slice.stop)
+                        # http://stackoverflow.com/questions/15139299/performance-of-numpy-searchsorted-is-poor-on-structured-arrays
+                        # sub_row_start = np.searchsorted(row["index"], vertex_slice.start, side="left")
+                        # sub_row_end = np.searchsorted(row["index"], vertex_slice.stop, side="left")
+                        sub_row_start = bisect_left(row["index"],
+                                                    vertex_slice.start)
+                        sub_row_end = bisect_left(row["index"],
+                                                  vertex_slice.stop)
 
-                        # Use these to build sub-row indexed from slice start
-                        sub_row = [(w, d, j - vertex_slice.start)
-                                   for (w, d, j) in row[row_start:row_end]]
+                        # Create copy of this slice of row
+                        sub_row = np.copy(row[sub_row_start:sub_row_end])
 
                         # If sub-row has any elements
                         if len(sub_row) != 0:
+                            # Make indices relative to vertex start
+                            sub_row["index"] -= vertex_slice.start
+
                             # Set flag indicating this sub-matrix
                             # should actually be processed
                             any_connections = True
 
-                            # Sort sub-row by delay
-                            sub_row.sort(key=itemgetter(1))
+                            # Determine which delay slot each sub-rob entry is in
+                            sub_row_delay_slot = (sub_row["delay"] - 1) / self.max_dtcm_delay_slots
 
-                            # Group sub-row into delay groups
-                            delay_row_iter = itertools.groupby(sub_row,
-                                                               delay_grouper)
-                            sub_rows[i] = [(e * self.max_dtcm_delay_slots,
-                                            list(delay_row))
-                                           for e, delay_row in delay_row_iter]
+                            # Sort sub-row by delay slot
+                            sub_row_order = np.argsort(sub_row_delay_slot)
+                            sub_row = sub_row[sub_row_order]
+                            sub_row_delay_slot = sub_row_delay_slot[sub_row_order]
 
-                            # If the first delay group of this sub-row
-                            # isn't extended, add new empty sub-row
-                            if sub_rows[i][0][0] != 0:
-                                sub_rows[i].insert(0, (0, []))
+                            # Take cumulative sum of the number of synapses
+                            # in each delay slot to obtain sections of
+                            # sub_row which belong in each delay slot
+                            sub_row_sections = np.cumsum(
+                                np.bincount(sub_row_delay_slot))
+                            sub_rows[i] = [
+                                (e * self.max_dtcm_delay_slots, r)
+                                for e, r in enumerate(
+                                    np.split(sub_row, sub_row_sections))
+                                    if e == 0 or len(r) > 0]
 
-                            # Count number of words in extension rows
-                            for e in sub_rows[i][1:]:
-                                num_extension_words += (3 + len(e[1]))
+                            # Check that first delay slot is always instantiated
+                            assert sub_rows[i][0][0] == 0
 
-                            # Update maximum number of columns
-                            max_cols = max(max_cols, len(sub_rows[i][0][1]))
+                            # Add number of synapses in all but 1st delay
+                            # slot and header for each extension row to total
+                            num_extension_words += (sub_row_sections[-1] - sub_row_sections[0])
+                            num_extension_words += (3 * (len(sub_row_sections) - 1))
+
+                            # Update maximum number of columns based
+                            # on length of first delay slot
+                            max_cols = max(max_cols, sub_row_sections[0])
                         # Otherwise, add empty row
                         else:
+                            assert False
                             sub_rows[i] = [(0, [])]
 
                     # If there any connections within this sub-matrix
@@ -240,21 +250,18 @@ class SynapticMatrix(Region):
             destination[2] = get_row_offset_length(next_row_offset,
                                                    len(next_row[1]),
                                                    self.LengthBits)
+        if destination[0] > 0:
+            # Extract the DTCM component of delay
+            # **NOTE** subtract one so there is a minimum of 1 slot of delay
+            dtcm_delay = 1 + ((row[1]["delay"] - 1) % self.max_dtcm_delay_slots)
 
-        # Convert row to numpy record array
-        row = np.asarray(row[1], dtype=row_dtype)
+            # Convert weight to fixed point
+            weight_fixed = float_to_weight(row[1]["weight"])
 
-        # Extract the DTCM component of delay
-        # **NOTE** subtract one so there is a minimum of 1 slot of delay
-        dtcm_delay = 1 + ((row["delay"] - 1) % self.max_dtcm_delay_slots)
+            # How much should we shift weights to be above index and delay
+            weight_shift = self.IndexBits + self.DelayBits
 
-        # Convert weight to fixed point
-        weight_fixed = float_to_weight(row["weight"])
-
-        # How much should we shift weights to be above index and delay
-        weight_shift = self.IndexBits + self.DelayBits
-
-        # Write row
-        destination[3:3 + len(row)] = (row["index"]
-                                       | (dtcm_delay << self.IndexBits)
-                                       | (weight_fixed << weight_shift))
+            # Write row
+            destination[3:3 + len(row[1])] = (row[1]["index"]
+                                        | (dtcm_delay << self.IndexBits)
+                                        | (weight_fixed << weight_shift))

--- a/pynn_spinnaker/spinnaker/regions/synaptic_matrix.py
+++ b/pynn_spinnaker/spinnaker/regions/synaptic_matrix.py
@@ -158,12 +158,12 @@ class SynapticMatrix(Region):
                         # Use bisect to find start and stop index of sub-row
                         # **NOTE** rows are already sorted by index
                         # http://stackoverflow.com/questions/15139299/performance-of-numpy-searchsorted-is-poor-on-structured-arrays
-                        # sub_row_start = np.searchsorted(row["index"], vertex_slice.start, side="left")
-                        # sub_row_end = np.searchsorted(row["index"], vertex_slice.stop, side="left")
-                        sub_row_start = bisect_left(row["index"],
-                                                    vertex_slice.start)
-                        sub_row_end = bisect_left(row["index"],
-                                                  vertex_slice.stop)
+                        sub_row_start = np.searchsorted(row["index"], vertex_slice.start, side="left")
+                        sub_row_end = np.searchsorted(row["index"], vertex_slice.stop, side="left")
+                        #sub_row_start = bisect_left(row["index"],
+                        #                            vertex_slice.start)
+                        #sub_row_end = bisect_left(row["index"],
+                        #                          vertex_slice.stop)
 
                         # Create copy of this slice of row
                         sub_row = np.copy(row[sub_row_start:sub_row_end])


### PR DESCRIPTION
This is my attempt at optimising the time spent processing synaptic matrices on the host. Previously the population-size ragged matrices were stored as numpy arrays of lists of tuples and partitioned in this format before being finally converted to numpy arrays for writing. This was adding a fair amount of time on top of the load time and in this change, once the population-size matrices are created they are converted into lists of numpy record arrays on which the partitioning is now performed. Running VABenchmark with 16000 neurons is now over 2 minutes faster and uses 200mb less RAM.

@mundya  - Any further optimisation thoughts would be much appreciated, specifically `SynapticMatrix._write_spinnaker_row` is called order of 10^5 times even when loading a 4 node board so any saving here would be good. 

@mossblaser - Writing seems to only going at about a megabyte/second, is that approximately the expected rate
